### PR TITLE
Invert --ro

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,7 @@ jobs:
           skopeo copy docker://zothub.io/machine/bootkit/bootkit:v0.0.16.230901-squashfs oci:oci:bootkit-squashfs
           mkdir upper
           lxc-usernsexec -s << EOF
-          atomfs mount --upper=upper oci:bootkit-squashfs dest
+          atomfs mount --writeable --upperdir=upper oci:bootkit-squashfs dest
           [ -d dest/bootkit ]
           touch dest/zz
           atomfs umount dest

--- a/mount.go
+++ b/mount.go
@@ -24,14 +24,14 @@ var mountCmd = cli.Command{
 			Usage: "Directory to use as writeable overlay",
 		},
 		cli.BoolFlag{
-			Name:  "ro",
-			Usage: "Do not make writeable using an overlay",
+			Name:  "writeable",
+			Usage: "Make writeable using an overlay",
 		},
 	},
 }
 
 func mountUsage(me string) error {
-	return fmt.Errorf("Usage: atomfs mount [--upper=/tmp/upperdir] [--ro=true] ocidir:tag target")
+	return fmt.Errorf("Usage: atomfs mount [--writeable [--upper=/tmp/upperdir]] ocidir:tag target")
 }
 
 func findImage(ctx *cli.Context) (string, string, error) {
@@ -104,10 +104,10 @@ func doMount(ctx *cli.Context) error {
 		return err
 	}
 
-	if ctx.Bool("ro") {
-		err = bind(target, rodest)
-	} else {
+	if ctx.Bool("writeable") {
 		err = overlay(target, rodest, metadir, ctx)
+	} else {
+		err = bind(target, rodest)
 	}
 
 	complete = true


### PR DESCRIPTION
Instead of defaulting to writeable mounts, default to readonly mounts, and take --writable as an argument to ask for writeable overlay.