### PR TITLE
make: add go test for newly added test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: atomfs
+all: gotest atomfs
 
 MAIN_VERSION ?= $(shell git describe --always --dirty || echo no-git)
 ifeq ($(MAIN_VERSION),$(filter $(MAIN_VERSION), "", no-git))
@@ -19,6 +19,9 @@ gofmt: .made-gofmt
 
 atomfs: .made-gofmt $(GO_SRC)
 	cd $(ROOT)/cmd/atomfs && go build -buildvcs=false -ldflags "$(VERSION_LDFLAGS)" -o $(ROOT)/bin/atomfs ./...
+
+gotest: $(GO_SRC)
+	go test -ldflags "$(VERSION_LDFLAGS)"  ./...
 
 clean:
 	rm -f $(ROOT)/cmd/atomfs/atomfs


### PR DESCRIPTION
moving pkgs over from stacker added some go test files, let's build those as part of `make` with the default target. This will get done in the github workflow too, because it just runs `make` with no args.