### PR TITLE
cli: improve usagemsgs

### DIFF
--- a/cmd/atomfs/mount.go
+++ b/cmd/atomfs/mount.go
@@ -16,9 +16,10 @@ import (
 )
 
 var mountCmd = cli.Command{
-	Name:   "mount",
-	Usage:  "mount atomfs image",
-	Action: doMount,
+	Name:      "mount",
+	Usage:     "mount atomfs image",
+	ArgsUsage: "ocidir:tag target",
+	Action:    doMount,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "persist, upper, upperdir",
@@ -50,6 +51,15 @@ func findImage(ctx *cli.Context) (string, string, error) {
 }
 
 func doMount(ctx *cli.Context) error {
+
+	if len(ctx.Args()) == 0 {
+		return mountUsage(ctx.App.Name)
+	}
+
+	ocidir, tag, err := findImage(ctx)
+	if err != nil {
+		return err
+	}
 	if !amPrivileged() {
 		fmt.Println("Please run as root, or in a user namespace")
 		fmt.Println(" You could try:")
@@ -59,11 +69,6 @@ func doMount(ctx *cli.Context) error {
 		fmt.Println("then run from that shell")
 		os.Exit(1)
 	}
-	ocidir, tag, err := findImage(ctx)
-	if err != nil {
-		return err
-	}
-
 	target := ctx.Args()[1]
 	metadir := filepath.Join(target, "meta")
 

--- a/cmd/atomfs/umount.go
+++ b/cmd/atomfs/umount.go
@@ -11,13 +11,14 @@ import (
 )
 
 var umountCmd = cli.Command{
-	Name:   "umount",
-	Usage:  "unmount atomfs image",
-	Action: doUmount,
+	Name:      "umount",
+	Usage:     "unmount atomfs image",
+	ArgsUsage: "mountpoint",
+	Action:    doUmount,
 }
 
 func umountUsage(me string) error {
-	return fmt.Errorf("Usage: %s mountpoint", me)
+	return fmt.Errorf("Usage: %s umount mountpoint", me)
 }
 
 func isMountpoint(p string) bool {


### PR DESCRIPTION
just a couple of changes to avoid tracebacks when someone just runs `atomfs mount` or `atomfs mount -h` to see what the usage should be.

for both, use ArgsUsage to add the args info to the help output

for mount, check #args and run findImage before the priv check so we get usage first

for umount update the message to include the command