### PR TITLE
verity: check after activation for any corruption

### DIFF
--- a/molecule.go
+++ b/molecule.go
@@ -61,6 +61,10 @@ func (m Molecule) mountUnderlyingAtoms() error {
 				if err != nil {
 					return err
 				}
+				err = squashfs.ConfirmExistingVerityDeviceCurrentValidity(mountpoint.Source)
+				if err != nil {
+					return err
+				}
 			}
 			continue
 		}


### PR DESCRIPTION
ActivateByVolumeKey does check for corruption via the dm_status task after activation, but if it finds that it was corrupted, it only logs that to stderr and returns 0 anyway.

For cases where corruption can be detected immediately, we want to fail the mounting, so we add a second check of the same task after activating the device (or after checking the hash on an existing device), and fail early.