### PR TITLE
add verify command

### DIFF
--- a/cmd/atomfs/main.go
+++ b/cmd/atomfs/main.go
@@ -18,6 +18,7 @@ func main() {
 	app.Commands = []cli.Command{
 		mountCmd,
 		umountCmd,
+		verifyCmd,
 	}
 
 	app.Flags = []cli.Flag{

--- a/cmd/atomfs/verify.go
+++ b/cmd/atomfs/verify.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/urfave/cli"
+	"machinerun.io/atomfs/mount"
+	"machinerun.io/atomfs/squashfs"
+)
+
+var verifyCmd = cli.Command{
+	Name:      "verify",
+	Usage:     "check atomfs image for dm-verity errors",
+	ArgsUsage: "atomfs mountpoint",
+	Action:    doVerify,
+}
+
+func verifyUsage(me string) error {
+	return fmt.Errorf("Usage: %s verify mountpoint", me)
+}
+
+func doVerify(ctx *cli.Context) error {
+	if ctx.NArg() != 1 {
+		return verifyUsage(ctx.App.Name)
+	}
+
+	mountpoint := ctx.Args()[0]
+
+	var err error
+
+	if !filepath.IsAbs(mountpoint) {
+		mountpoint, err = filepath.Abs(mountpoint)
+		if err != nil {
+			return fmt.Errorf("Failed to find mountpoint: %w", err)
+		}
+	}
+
+	if !isMountpoint(mountpoint) {
+		return fmt.Errorf("%s is not a mountpoint", mountpoint)
+	}
+
+	// hidden by the final overlay mount, but visible in the mountinfo:
+	// $mountpoint/meta/mounts/* - the original squashfs mounts
+	mountsdir := filepath.Join(mountpoint, "meta", "mounts")
+
+	mounts, err := mount.ParseMounts("/proc/self/mountinfo")
+	if err != nil {
+		return err
+	}
+
+	// quick check that the top level mount is an overlayfs as expected:
+	for _, m := range mounts {
+		if m.Target == mountpoint && m.FSType != "overlay" {
+			return fmt.Errorf("%s is not an overlayfs, are you sure it is a mounted molecule? %+v", mountpoint, m)
+		}
+	}
+
+	allOK := true
+	for _, m := range mounts {
+
+		if m.FSType != "squashfs" {
+			continue
+		}
+
+		if !strings.HasPrefix(m.Target, mountsdir) {
+			continue
+		}
+
+		err = squashfs.ConfirmExistingVerityDeviceCurrentValidity(m.Source)
+		if err != nil {
+			fmt.Printf("%s: CORRUPTION FOUND\n", m.Source)
+			allOK = false
+		} else {
+			fmt.Printf("%s: OK\n", m.Source)
+		}
+	}
+
+	if allOK {
+		return nil
+	}
+	return fmt.Errorf("Found corrupt devices in molecule")
+}


### PR DESCRIPTION
add a command to check if any underlying devices of an atomfs mountpoint have had any corruption detected by dm-verity:

```
$ sudo ../atomfs/bin/atomfs verify happymountpoint/
/dev/mapper/50bd5ba895c5648b03f596a0d6b3e6ba3c0046f67f1339e22306670d418ab0de-verity: OK
/dev/mapper/36bbe7fcd9d59214ccfed627a24ef27ee3dc884b8adaecf63bab3a6d23a38c97-verity: OK
/dev/mapper/ff6f0586075905d3b0c4edfe4cb3cab63143767df4acf824b1fb318933260741-verity: OK
$ sudo ../atomfs/bin/atomfs verify shamefulmountpoint/
/dev/mapper/4c798c57305b4a14d1959295ebcdd10c290cb48c7675b78556b711d83cf600ac-verity: CORRUPTION FOUND
/dev/mapper/024eea02b94f8424a34bab308aa6471fd37e9f81fa315e9205024f672bc79b20-verity: OK
Error: Found corrupt devices in molecule
```

Closes #19 