### PR TITLE
make config and metadata visible

### DIFF
--- a/cmd/atomfs/mount.go
+++ b/cmd/atomfs/mount.go
@@ -70,7 +70,12 @@ func doMount(ctx *cli.Context) error {
 		os.Exit(1)
 	}
 	target := ctx.Args()[1]
-	metadir := filepath.Join(target, "meta")
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return err
+	}
+
+	metadir := filepath.Join("/run", "atomfs", "meta", ReplacePathSeparators(absTarget))
 
 	complete := false
 
@@ -92,12 +97,24 @@ func doMount(ctx *cli.Context) error {
 	if err = EnsureDir(rodest); err != nil {
 		return err
 	}
+	absOCIDir, err := filepath.Abs(ocidir)
+	if err != nil {
+		return err
+	}
+	absMetadir, err := filepath.Abs(metadir)
+	if err != nil {
+		return err
+	}
+	absRODest, err := filepath.Abs(rodest)
+	if err != nil {
+		return err
+	}
 
 	opts := atomfs.MountOCIOpts{
-		OCIDir:       ocidir,
-		MetadataPath: metadir,
+		OCIDir:       absOCIDir,
+		MetadataPath: absMetadir,
 		Tag:          tag,
-		Target:       rodest,
+		Target:       absRODest,
 	}
 
 	mol, err := atomfs.BuildMoleculeFromOCI(opts)

--- a/cmd/atomfs/umount.go
+++ b/cmd/atomfs/umount.go
@@ -50,11 +50,12 @@ func doUmount(ctx *cli.Context) error {
 		errs = append(errs, fmt.Errorf("Failed unmounting %s: %v", mountpoint, err))
 	}
 
-	// Now that we've unmounted the mountpoint, we expect the following
-	// under there:
-	// $mountpoint/meta/ro - the original readonly overlay mountpoint
-	// $mountpoint/meta/mounts/* - the original squashfs mounts
-	metadir := filepath.Join(mountpoint, "meta")
+	// We expect the following in the metadir
+	//
+	// $metadir/ro - the original readonly overlay mountpoint
+	// $metadir/meta/mounts/* - the original squashfs mounts
+	// $metadir/meta/config.json
+	metadir := filepath.Join("/run/atomfs/meta", ReplacePathSeparators(mountpoint))
 	p := filepath.Join(metadir, "ro")
 	err = syscall.Unmount(p, 0)
 	if err != nil {
@@ -65,7 +66,7 @@ func doUmount(ctx *cli.Context) error {
 	mounts, err := os.ReadDir(mountsdir)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("Failed reading list of mounts: %v", err))
-		return fmt.Errorf("Encountered errors: %#v", errs)
+		return fmt.Errorf("Encountered errors: %v", errs)
 	}
 
 	for _, m := range mounts {

--- a/cmd/atomfs/utils.go
+++ b/cmd/atomfs/utils.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 func EnsureDir(dir string) error {
@@ -19,4 +20,13 @@ func PathExists(d string) bool {
 		return false
 	}
 	return true
+}
+
+// remove dir separators to make one dir name. It is OK that this can't be
+// cleanly backed out, we don't need it to
+func ReplacePathSeparators(p string) string {
+	if p[0] == '/' {
+		p = p[1:]
+	}
+	return strings.ReplaceAll(p, "/", "-")
 }

--- a/molecule.go
+++ b/molecule.go
@@ -165,6 +165,11 @@ func (m Molecule) Mount(dest string) error {
 		return err
 	}
 
+	err = m.config.WriteToFile(filepath.Join(m.config.MetadataPath, "config.json"))
+	if err != nil {
+		return err
+	}
+
 	// now, do the actual overlay mount
 	err = unix.Mount("overlay", dest, "overlay", 0, mntOpts)
 	return errors.Wrapf(err, "couldn't do overlay mount to %s, opts: %s", dest, mntOpts)

--- a/oci.go
+++ b/oci.go
@@ -1,6 +1,8 @@
 package atomfs
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"path"
 
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -24,6 +26,18 @@ func (c MountOCIOpts) AtomsPath(parts ...string) string {
 func (c MountOCIOpts) MountedAtomsPath(parts ...string) string {
 	mounts := path.Join(c.MetadataPath, "mounts")
 	return path.Join(append([]string{mounts}, parts...)...)
+}
+
+func (c MountOCIOpts) WriteToFile(filename string) error {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(filename, b, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func BuildMoleculeFromOCI(opts MountOCIOpts) (Molecule, error) {


### PR DESCRIPTION
"write molecule config to metadata path" is important to be able to trace an event that points at a failed DM Verity volume, through its molecule mountpoint, to an OCI image and potentially to a container running that image that we then need to stop.

"move metadata path to /run" is handy for testing, but is not strictly required, since it only changes the behavior of the `atomfs` binary. Other programs using atomfs as a package are free to set the metadata path however they want, if they need it to be accessible while the molecule is mounted.

Fixes #21 