### PR TITLE
fix umount cleanup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,10 +67,10 @@ jobs:
         run: |
           make batstest
       - name: Upload code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true # optional (default = false)
-          files: ./coverage.txt
+          files: ./unit-coverage.txt,./integ-coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }} # required
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ BATS_VERSION := v1.10.0
 STACKER = $(TOOLS_D)/bin/stacker
 STACKER_VERSION := v1.0.0
 TOOLS_D := $(ROOT)/tools
+GOCOVERDIR ?= $(ROOT)
 
 export PATH := $(TOOLS_D)/bin:$(PATH)
 
@@ -25,11 +26,13 @@ gofmt: .made-gofmt
 		{ echo "gofmt made changes: $$o" 1>&2; exit 1; }
 	@touch $@
 
-atomfs: .made-gofmt $(GO_SRC)
-	cd $(ROOT)/cmd/atomfs && go build -buildvcs=false -ldflags "$(VERSION_LDFLAGS)" -o $(ROOT)/bin/atomfs ./...
+atomfs atomfs-cover: .made-gofmt $(GO_SRC)
+	cd $(ROOT)/cmd/atomfs && go build $(BUILDCOVERFLAGS) -buildvcs=false -ldflags "$(VERSION_LDFLAGS)" -o $(ROOT)/bin/$@ ./...
+
+atomfs-cover: BUILDCOVERFLAGS=-cover
 
 gotest: $(GO_SRC)
-	go test -coverprofile=coverage.txt -ldflags "$(VERSION_LDFLAGS)"  ./...
+	go test -coverprofile=unit-coverage.txt -ldflags "$(VERSION_LDFLAGS)"  ./...
 
 $(STACKER):
 	mkdir -p $(TOOLS_D)/bin
@@ -46,9 +49,14 @@ $(BATS):
 	git clone --depth 1 https://github.com/bats-core/bats-assert $(ROOT)/test/test_helper/bats-assert
 	git clone --depth 1 https://github.com/bats-core/bats-file $(ROOT)/test/test_helper/bats-file
 
-batstest: $(BATS) $(STACKER) atomfs test/random.txt testimages
-	cd $(ROOT)/test; sudo $(BATS) --tap --timing priv-*.bats
-	cd $(ROOT)/test; $(BATS) --tap --timing unpriv-*.bats
+batstest: $(BATS) $(STACKER) atomfs-cover test/random.txt testimages
+	cd $(ROOT)/test; sudo GOCOVERDIR=$(GOCOVERDIR) $(BATS) --tap --timing priv-*.bats
+	cd $(ROOT)/test; GOCOVERDIR=$(GOCOVERDIR) $(BATS) --tap --timing unpriv-*.bats
+	go tool covdata textfmt -i $(GOCOVERDIR) -o integ-coverage.txt
+
+covreport: gotest batstest
+	go tool cover -func=unit-coverage.txt
+	go tool cover -func=integ-coverage.txt
 
 testimages: /tmp/atomfs-test-oci/.copydone
 	@echo "busybox image exists at /tmp/atomfs-test-oci already"

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,16 @@ $(BATS):
 	git clone --depth 1 https://github.com/bats-core/bats-assert $(ROOT)/test/test_helper/bats-assert
 	git clone --depth 1 https://github.com/bats-core/bats-file $(ROOT)/test/test_helper/bats-file
 
-batstest: $(BATS) $(STACKER) atomfs test/random.txt
+batstest: $(BATS) $(STACKER) atomfs test/random.txt testimages
 	cd $(ROOT)/test; sudo $(BATS) --tap --timing priv-*.bats
 	cd $(ROOT)/test; $(BATS) --tap --timing unpriv-*.bats
+
+testimages: /tmp/atomfs-test-oci/.copydone
+	@echo "busybox image exists at /tmp/atomfs-test-oci already"
+
+/tmp/atomfs-test-oci/.copydone:
+	skopeo copy docker://public.ecr.aws/docker/library/busybox:stable oci:/tmp/atomfs-test-oci:busybox
+	touch $@
 
 test/random.txt:
 	dd if=/dev/random of=/dev/stdout count=2048 | base64 > test/random.txt

--- a/cmd/atomfs/umount.go
+++ b/cmd/atomfs/umount.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
-	"syscall"
 
 	"github.com/urfave/cli"
 	"machinerun.io/atomfs"
@@ -39,9 +37,7 @@ func doUmount(ctx *cli.Context) error {
 	}
 
 	mountpoint := ctx.Args()[0]
-
 	var err error
-	var errs []error
 
 	if !filepath.IsAbs(mountpoint) {
 		mountpoint, err = filepath.Abs(mountpoint)
@@ -50,53 +46,5 @@ func doUmount(ctx *cli.Context) error {
 		}
 	}
 
-	// We expect the argument to be the mountpoint of the overlay
-	err = syscall.Unmount(mountpoint, 0)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("Failed unmounting %s: %v", mountpoint, err))
-	}
-
-	// We expect the following in the metadir
-	//
-	// $metadir/mounts/* - the original squashfs mounts
-	// $metadir/meta/config.json
-
-	// TODO: want to know mountnsname for a target mountpoint... not for our current proc???
-	mountNSName, err := atomfs.GetMountNSName()
-	if err != nil {
-		errs = append(errs, fmt.Errorf("Failed to get mount namespace name"))
-	}
-	metadir := filepath.Join(atomfs.RuntimeDir(ctx.String("metadir")), "meta", mountNSName, atomfs.ReplacePathSeparators(mountpoint))
-
-	mountsdir := filepath.Join(metadir, "mounts")
-	mounts, err := os.ReadDir(mountsdir)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("Failed reading list of mounts: %v", err))
-		return fmt.Errorf("Encountered errors: %v", errs)
-	}
-
-	for _, m := range mounts {
-		p := filepath.Join(mountsdir, m.Name())
-		if !m.IsDir() || !isMountpoint(p) {
-			continue
-		}
-
-		err = syscall.Unmount(p, 0)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("Failed unmounting squashfs dir %s: %v", p, err))
-		}
-	}
-
-	if len(errs) != 0 {
-		for i, e := range errs {
-			fmt.Printf("Error %d: %v\n", i, e)
-		}
-		return fmt.Errorf("Encountered errors %d: %v", len(errs), errs)
-	}
-
-	if err := os.RemoveAll(metadir); err != nil {
-		return fmt.Errorf("Failed removing %q: %v", metadir, err)
-	}
-
-	return nil
+	return atomfs.UmountWithMetadir(mountpoint, ctx.String("metadir"))
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -12,7 +12,8 @@ export PATH="$TOOLS_D/bin:$ROOT_D/bin:$PATH"
 
 build_image_at() {
     cd $1
-    sudo env "PATH=$PATH" stacker --oci-dir $1/oci --stacker-dir=$1/stacker --roots-dir=$1/roots --debug build -f $(dirname $BATS_TEST_FILENAME)/1.stacker.yaml --layer-type squashfs
-    sudo env "PATH=$PATH" stacker --oci-dir $1/oci-no-verity --stacker-dir=$1/stacker --roots-dir=$1/roots  --debug build -f $(dirname $BATS_TEST_FILENAME)/1.stacker.yaml --layer-type squashfs --no-squashfs-verity
+    stackerfilename=${2:-1.stacker.yaml}
+    sudo env "PATH=$PATH" stacker --oci-dir $1/oci --stacker-dir=$1/stacker --roots-dir=$1/roots --debug build -f $(dirname $BATS_TEST_FILENAME)/$stackerfilename --layer-type squashfs
+    sudo env "PATH=$PATH" stacker --oci-dir $1/oci-no-verity --stacker-dir=$1/stacker --roots-dir=$1/roots  --debug build -f $(dirname $BATS_TEST_FILENAME)/$stackerfilename --layer-type squashfs --no-squashfs-verity
     sudo chown -R $(id -un):$(id -gn) $1/oci $1/oci-no-verity $1/stacker $1/roots
 }

--- a/test/mount-umount-trees.stacker.yaml
+++ b/test/mount-umount-trees.stacker.yaml
@@ -1,0 +1,20 @@
+base:
+    from:
+        type: oci
+        url: /tmp/atomfs-test-oci:busybox
+    run: touch /base
+a:
+    from:
+        type: built
+        tag: base
+    run: touch /a
+b:
+    from:
+        type: built
+        tag: base
+    run: touch /b
+c:
+    from:
+        type: built
+        tag: base
+    run: touch /c

--- a/test/priv-mount-umount-mount.bats
+++ b/test/priv-mount-umount-mount.bats
@@ -37,18 +37,18 @@ function verity_checkusedloops() {
 
     echo MOUNT A
     mkdir -p $MP/a
-    run atomfs --debug mount ${BATS_SUITE_TMPDIR}/oci:a-squashfs $MP/a
+    run atomfs-cover --debug mount ${BATS_SUITE_TMPDIR}/oci:a-squashfs $MP/a
     assert_success
     assert_file_exists $MP/a/a
 
     echo MOUNT B
     mkdir -p $MP/b
-    run atomfs --debug mount ${BATS_SUITE_TMPDIR}/oci:b-squashfs $MP/b
+    run atomfs-cover --debug mount ${BATS_SUITE_TMPDIR}/oci:b-squashfs $MP/b
     assert_success
     assert_file_exists $MP/b/b
 
     echo UMOUNT B
-    atomfs --debug umount $MP/b
+    atomfs-cover --debug umount $MP/b
     assert_success
 
     # first layer should still exist since a is still mounted
@@ -58,12 +58,12 @@ function verity_checkusedloops() {
 
     echo MOUNT C
     mkdir -p $MP/c
-    atomfs --debug mount ${BATS_SUITE_TMPDIR}/oci:c-squashfs $MP/c
+    atomfs-cover --debug mount ${BATS_SUITE_TMPDIR}/oci:c-squashfs $MP/c
     assert_success
     assert_file_exists $MP/c/c
 
     echo UMOUNT A
-    atomfs --debug umount $MP/a
+    atomfs-cover --debug umount $MP/a
     assert_success
 
     # first layer should still exist since c is still mounted
@@ -75,7 +75,7 @@ function verity_checkusedloops() {
     assert_file_exists $MP/c/c
     assert_file_exists $MP/c/bin/sh
 
-    atomfs --debug umount $MP/c
+    atomfs-cover --debug umount $MP/c
     assert_success
 
     # c's last layer shouldn't exist any more, since it is unique

--- a/test/priv-mount-umount-mount.bats
+++ b/test/priv-mount-umount-mount.bats
@@ -1,0 +1,97 @@
+load helpers
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+load 'test_helper/bats-file/load'
+
+function setup_file() {
+    check_root
+    build_image_at $BATS_SUITE_TMPDIR mount-umount-trees.stacker.yaml
+    export ATOMFS_TEST_RUN_DIR=${BATS_SUITE_TMPDIR}/run/atomfs
+    mkdir -p $ATOMFS_TEST_RUN_DIR
+    export MY_MNTNSNAME=$(readlink /proc/self/ns/mnt | cut -c 6-15)
+}
+
+function setup() {
+    export MP=${BATS_TEST_TMPDIR}/testmountpoint
+    mkdir -p $MP
+}
+
+function verity_checkusedloops() {
+    # search for loopdevices which have backing files with the current
+    # BATS_TEST_DIRNAME value and complain if they're present.
+    local usedloops="" found="" x=""
+    for ((x=0; x<5; x++)); do
+        usedloops=$(losetup -a | grep $BATS_TEST_DIRNAME || echo)
+        if [ -n "$usedloops" ]; then
+            found=1
+            udevadm settle
+        else
+            return 0
+        fi
+    done
+    echo "found used loops in testdir=$BATS_TEST_DIRNAME :$usedloops" >&3
+    [ $found = 1 ]
+}
+
+@test "mount + umount + mount a tree of images works" {
+
+    echo MOUNT A
+    mkdir -p $MP/a
+    run atomfs --debug mount ${BATS_SUITE_TMPDIR}/oci:a-squashfs $MP/a
+    assert_success
+    assert_file_exists $MP/a/a
+
+    echo MOUNT B
+    mkdir -p $MP/b
+    run atomfs --debug mount ${BATS_SUITE_TMPDIR}/oci:b-squashfs $MP/b
+    assert_success
+    assert_file_exists $MP/b/b
+
+    echo UMOUNT B
+    atomfs --debug umount $MP/b
+    assert_success
+
+    # first layer should still exist since a is still mounted
+    manifest=$(cat ${BATS_SUITE_TMPDIR}/oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
+    first_layer_hash=$(cat ${BATS_SUITE_TMPDIR}/oci/blobs/sha256/$manifest | jq -r .layers[0].digest | cut -f2 -d:)
+    assert_block_exists "/dev/mapper/$first_layer_hash-verity"
+
+    echo MOUNT C
+    mkdir -p $MP/c
+    atomfs --debug mount ${BATS_SUITE_TMPDIR}/oci:c-squashfs $MP/c
+    assert_success
+    assert_file_exists $MP/c/c
+
+    echo UMOUNT A
+    atomfs --debug umount $MP/a
+    assert_success
+
+    # first layer should still exist since c is still mounted
+    manifest=$(cat ${BATS_SUITE_TMPDIR}/oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
+    first_layer_hash=$(cat ${BATS_SUITE_TMPDIR}/oci/blobs/sha256/$manifest | jq -r .layers[0].digest | cut -f2 -d:)
+    assert_block_exists "/dev/mapper/$first_layer_hash-verity"
+
+    # c should still be ok
+    assert_file_exists $MP/c/c
+    assert_file_exists $MP/c/bin/sh
+
+    atomfs --debug umount $MP/c
+    assert_success
+
+    # c's last layer shouldn't exist any more, since it is unique
+    manifest=$(cat ${BATS_SUITE_TMPDIR}/oci/index.json | jq -r .manifests[0].digest | cut -f2 -d:)
+    last_layer_num=$(($(cat ${BATS_SUITE_TMPDIR}/oci/blobs/sha256/$manifest | jq -r '.layers | length')-1))
+    last_layer_hash=$(cat ${BATS_SUITE_TMPDIR}/oci/blobs/sha256/$manifest | jq -r .layers[$last_layer_num].digest | cut -f2 -d:)
+    echo "last layer hash is $last_layer_hash"
+    assert_block_not_exists /dev/mapper/$last_layer_hash-verity
+    verity_checkusedloops
+
+    # mount points and meta dir should exist but be empty:
+    for subdir in a b c; do
+        assert_dir_exists $MP/$subdir
+        assert [ -z $( ls -A $MP/$subdir) ]
+    done
+    assert_dir_exists $ATOMFS_TEST_RUN_DIR/meta/$MY_MNTNSNAME/
+    assert [ -z $( ls -A $ATOMFS_TEST_RUN_DIR/meta/$MY_MNTNSNAME/) ]
+
+}

--- a/test/priv-mount.bats
+++ b/test/priv-mount.bats
@@ -17,7 +17,7 @@ function setup() {
 }
 
 @test "RO mount/umount and verify of good image works" {
-    run atomfs --debug mount ${BATS_SUITE_TMPDIR}/oci:test-squashfs $MP
+    run atomfs-cover --debug mount ${BATS_SUITE_TMPDIR}/oci:test-squashfs $MP
     assert_success
     assert_file_exists $MP/1.README.md
     assert_file_exists $MP/random.txt
@@ -26,10 +26,10 @@ function setup() {
     run touch $MP/do-not-let-me
     assert_failure
 
-    run atomfs verify $MP
+    run atomfs-cover verify $MP
     assert_success
 
-    run atomfs --debug umount $MP
+    run atomfs-cover --debug umount $MP
     assert_success
 
     # mount point and meta dir should exist but be empty:
@@ -41,7 +41,7 @@ function setup() {
 }
 
 @test "mount with missing verity data fails" {
-    run atomfs --debug mount ${BATS_SUITE_TMPDIR}/oci-no-verity:test-squashfs $MP
+    run atomfs-cover --debug mount ${BATS_SUITE_TMPDIR}/oci-no-verity:test-squashfs $MP
     assert_failure
     assert_line --partial "is missing verity data"
 
@@ -54,10 +54,10 @@ function setup() {
 }
 
 @test "mount with missing verity data passes if you ignore it" {
-    run atomfs --debug mount --allow-missing-verity ${BATS_SUITE_TMPDIR}/oci-no-verity:test-squashfs $MP
+    run atomfs-cover --debug mount --allow-missing-verity ${BATS_SUITE_TMPDIR}/oci-no-verity:test-squashfs $MP
     assert_success
 
-    run atomfs --debug umount $MP
+    run atomfs-cover --debug umount $MP
     assert_success
 
     # mount point and meta dir should exist but be empty:
@@ -69,7 +69,7 @@ function setup() {
 }
 
 @test "mount/umount with writeable overlay" {
-    run atomfs --debug mount --writeable ${BATS_SUITE_TMPDIR}/oci:test-squashfs $MP
+    run atomfs-cover --debug mount --writeable ${BATS_SUITE_TMPDIR}/oci:test-squashfs $MP
     assert_success
     assert_file_exists $MP/1.README.md
     assert_file_exists $MP/random.txt
@@ -81,7 +81,7 @@ function setup() {
     run cp $MP/1.README.md $MP/3.README.md
     assert_success
 
-    run atomfs --debug umount $MP
+    run atomfs-cover --debug umount $MP
     assert_success
 
     # mount point and meta dir should exist but be empty:
@@ -94,7 +94,7 @@ function setup() {
 @test "mount with writeable overlay in separate dir" {
     export PERSIST_DIR=${BATS_TEST_TMPDIR}/persist-dir
     mkdir -p $PERSIST_DIR
-    run atomfs --debug mount --persist=${PERSIST_DIR} ${BATS_SUITE_TMPDIR}/oci:test-squashfs $MP
+    run atomfs-cover --debug mount --persist=${PERSIST_DIR} ${BATS_SUITE_TMPDIR}/oci:test-squashfs $MP
     assert_success
     assert_file_exists $MP/1.README.md
     assert_file_exists $MP/random.txt
@@ -108,7 +108,7 @@ function setup() {
     assert_file_exists $PERSIST_DIR/persist/3.README.md
     assert_file_not_exists $PERSIST_DIR/persist/1.README.md
 
-    run atomfs --debug umount $MP
+    run atomfs-cover --debug umount $MP
     assert_success
     # mount point and meta dir should exist but be empty:
     assert_dir_exists $MP

--- a/test/priv-verify.bats
+++ b/test/priv-verify.bats
@@ -26,7 +26,7 @@ function setup_file() {
     assert_failure
 
     mkdir -p mountpoint
-    run atomfs --debug mount ${BATS_TEST_TMPDIR}/oci:test-squashfs mountpoint
+    run atomfs-cover --debug mount ${BATS_TEST_TMPDIR}/oci:test-squashfs mountpoint
     assert_failure
 
 }

--- a/test/unpriv-guestmount.bats
+++ b/test/unpriv-guestmount.bats
@@ -26,7 +26,7 @@ function setup() {
     export INNER_MNTNSNAME=\$(readlink /proc/self/ns/mnt | cut -c 6-15)
 
     set +e
-    atomfs --debug mount --persist=\$PERSIST_DIR ${BATS_SUITE_TMPDIR}/oci:test-squashfs $MP
+    atomfs-cover --debug mount --persist=\$PERSIST_DIR ${BATS_SUITE_TMPDIR}/oci:test-squashfs $MP
     [ \$? -eq 0 ] && {
       echo guestmount without allow-missing should fail, because we do not have verity
       exit 1
@@ -34,13 +34,13 @@ function setup() {
     echo "XFAIL: guestmount without allow-missing did fail"
     set -e
 
-    atomfs --debug mount --allow-missing-verity --persist=\$PERSIST_DIR ${BATS_SUITE_TMPDIR}/oci:test-squashfs $MP
+    atomfs-cover --debug mount --allow-missing-verity --persist=\$PERSIST_DIR ${BATS_SUITE_TMPDIR}/oci:test-squashfs $MP
     [ -f $MP/1.README.md ]
     [ -f $MP/random.txt ]
     touch $MP/let-me-write
 
     set +e
-    atomfs --debug verify $MP
+    atomfs-cover --debug verify $MP
     [ \$? -eq 0 ] && {
        echo mount with squashfuse ignores verity, so verify should have failed, output should include warning
        exit 1
@@ -51,7 +51,7 @@ function setup() {
     find $ATOMFS_TEST_RUN_DIR/meta/\$INNER_MNTNSNAME/ -name config.json|xargs cat
     find $ATOMFS_TEST_RUN_DIR/meta/\$INNER_MNTNSNAME/
 
-    atomfs --debug umount $MP
+    atomfs-cover --debug umount $MP
     [ -f \$PERSIST_DIR/persist/let-me-write ]
 
     # mount point and meta dir should be empty
@@ -76,20 +76,20 @@ EOF
 
     export INNER_MNTNSNAME=\$(readlink /proc/self/ns/mnt | cut -c 6-15)
 
-    atomfs --debug mount --allow-missing-verity --persist=\$PERSIST_DIR ${BATS_SUITE_TMPDIR}/oci-no-verity:test-squashfs $MP
+    atomfs-cover --debug mount --allow-missing-verity --persist=\$PERSIST_DIR ${BATS_SUITE_TMPDIR}/oci-no-verity:test-squashfs $MP
     [ -f $MP/1.README.md ]
     [ -f $MP/random.txt ]
     touch $MP/let-me-write
 
     set +e
-    atomfs --debug verify $MP
+    atomfs-cover --debug verify $MP
     [ \$? -eq 0 ] && {
        echo mount with squashfuse ignores verity, so verify should have failed, output should include warning
        exit 1
     }
     set -e
 
-    atomfs --debug umount $MP
+    atomfs-cover --debug umount $MP
     [ -f \$PERSIST_DIR/persist/let-me-write ]
 
     [ -d $MP ]
@@ -114,11 +114,11 @@ EOF
 
     export INNER_MNTNSNAME=\$(readlink /proc/self/ns/mnt | cut -c 6-15)
 
-    atomfs --debug mount --allow-missing-verity --metadir=\$META_DIR ${BATS_SUITE_TMPDIR}/oci-no-verity:test-squashfs $MP
+    atomfs-cover --debug mount --allow-missing-verity --metadir=\$META_DIR ${BATS_SUITE_TMPDIR}/oci-no-verity:test-squashfs $MP
     [ -f $MP/1.README.md ]
     [ -f $MP/random.txt ]
 
-    atomfs --debug umount --metadir=\$META_DIR $MP
+    atomfs-cover --debug umount --metadir=\$META_DIR $MP
 
     [ -d $MP ]
     [ -z \$( ls -A $MP) ]

--- a/test/unpriv-guestmount.bats
+++ b/test/unpriv-guestmount.bats
@@ -31,6 +31,7 @@ function setup() {
       echo guestmount without allow-missing should fail, because we do not have verity
       exit 1
     }
+    echo "XFAIL: guestmount without allow-missing did fail"
     set -e
 
     atomfs --debug mount --allow-missing-verity --persist=\$PERSIST_DIR ${BATS_SUITE_TMPDIR}/oci:test-squashfs $MP
@@ -44,6 +45,7 @@ function setup() {
        echo mount with squashfuse ignores verity, so verify should have failed, output should include warning
        exit 1
     }
+    echo "XFAIL: verify did fail on squashfuse mounted molecule"
     set -e
 
     find $ATOMFS_TEST_RUN_DIR/meta/\$INNER_MNTNSNAME/ -name config.json|xargs cat


### PR DESCRIPTION
Fix cleanup of underlying molecules, which was broken by recent changes that moved the mount points for the atoms under a directory named after the final mount point - so the refcounting broke.

the fix is to always unmount the atom mount points and then just check if the backing device is still used, and clean it up if not. No "refcounting" in code here, just using the mount table to check if it's in use.

I think this will not work great if there is a mix of mounts in different mount namespaces that use the same atoms.
I am not sure what a good solution for that case would look like.

This was not caught by tests until we ran stacker tests on it, where a test that should have been moved to this repo when we originally split it out caught the cleanup issue. I've moved that test here.