### PR TITLE
Export the default extraction policy list and the policy environment …

### DIFF
--- a/pkg/erofs/erofs.go
+++ b/pkg/erofs/erofs.go
@@ -31,6 +31,10 @@ type erofsFuseInfoStruct struct {
 var once sync.Once
 var erofsFuseInfo = erofsFuseInfoStruct{"", ""}
 
+const PolicyEnvName = "STACKER_EROFS_EXTRACT_POLICY"
+const DefPolicies = "kmount erofsfuse fsck.erofs"
+const AllPolicies = "kmount erofsfuse fsck.erofs"
+
 func MakeErofs(tempdir string, rootfs string, eps *common.ExcludePaths, verity vrty.VerityMetadata) (io.ReadCloser, string, string, error) {
 	var excludesFile string
 	var err error
@@ -495,11 +499,9 @@ func ExtractSingleErofsPolicy(erofsFile, extractDir string, policy *ExtractPolic
 // wik()th that.
 func ExtractSingleErofs(erofsFile string, extractDir string) error {
 	exPolInfo.once.Do(func() {
-		const envName = "STACKER_EROFS_EXTRACT_POLICY"
-		const defPolicy = "kmount erofsfuse fsc.erofs"
-		val := os.Getenv(envName)
+		val := os.Getenv(PolicyEnvName)
 		if val == "" {
-			val = defPolicy
+			val = DefPolicies
 		}
 		exPolInfo.policy, exPolInfo.err = NewExtractPolicy(strings.Fields(val)...)
 		if exPolInfo.err == nil {

--- a/pkg/squashfs/squashfs.go
+++ b/pkg/squashfs/squashfs.go
@@ -32,6 +32,10 @@ type squashFuseInfoStruct struct {
 var once sync.Once
 var squashFuseInfo = squashFuseInfoStruct{"", "", false}
 
+const PolicyEnvName = "STACKER_SQUASHFS_EXTRACT_POLICY"
+const DefPolicies = "kmount squashfuse unsquashfs"
+const AllPolicies = "kmount squashfuse unsquashfs"
+
 func MakeSquashfs(tempdir string, rootfs string, eps *common.ExcludePaths, verity vrty.VerityMetadata) (io.ReadCloser, string, string, error) {
 	var excludesFile string
 	var err error
@@ -553,11 +557,9 @@ func ExtractSingleSquashPolicy(squashFile, extractDir string, policy *ExtractPol
 // wik()th that.
 func ExtractSingleSquash(squashFile string, extractDir string) error {
 	exPolInfo.once.Do(func() {
-		const envName = "STACKER_SQUASHFS_EXTRACT_POLICY"
-		const defPolicy = "kmount squashfuse unsquashfs"
-		val := os.Getenv(envName)
+		val := os.Getenv(PolicyEnvName)
 		if val == "" {
-			val = defPolicy
+			val = DefPolicies
 		}
 		exPolInfo.policy, exPolInfo.err = NewExtractPolicy(strings.Fields(val)...)
 		if exPolInfo.err == nil {


### PR DESCRIPTION
…variable name

For both squash and erofs, export consts so that callers can know which environment variable to use to set the policies (PolicyEnvName), and the default policy list (DefPolicies).

Also add a third const (AllPolicies) which is the full list of valid extraction policies.  As it happens, those are the same as the default ones right now, but that needn't always be the case.

(This addresses one part of issue #29, but doesn't close all of it)