### PR TITLE
fix: umount: delete the right metapath

### DIFF
--- a/pkg/molecule/molecule.go
+++ b/pkg/molecule/molecule.go
@@ -415,11 +415,7 @@ func UmountWithMetadir(dest, metadirArg string) error {
 		}
 	}
 
-	mountNSName, err := common.GetMountNSName()
-	if err != nil {
-		return err
-	}
-	destMetaDir := filepath.Join(common.RuntimeDir(metadir), "meta", mountNSName, common.ReplacePathSeparators(dest))
+	destMetaDir := filepath.Join(common.RuntimeDir(metadir))
 	if err := os.RemoveAll(destMetaDir); err != nil {
 		return err
 	}


### PR DESCRIPTION
We were deleting /run/atomfs/meta/ID/destpath/meta/ID/destpath. So doing

atomfs mount oci:a dest
atomfs umount dest
atomfs mount oci:a dest

would fail as /run/atomfs/meta/ID/destpath still existed.