### PR TITLE
test: don't leave stacker binaries around

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,8 @@ gotest: $(GO_SRC)
 
 $(STACKER):
 	mkdir -p $(TOOLS_D)/bin
-	wget --progress=dot:giga https://github.com/project-stacker/stacker/releases/download/$(STACKER_VERSION)/stacker
-	chmod +x stacker
-	cp stacker $(TOOLS_D)/bin/
+	wget --progress=dot:giga https://github.com/project-stacker/stacker/releases/download/$(STACKER_VERSION)/stacker --output-document $(TOOLS_D)/bin/stacker
+	chmod +x $(TOOLS_D)/bin/stacker
 
 $(BATS):
 	mkdir -p $(TOOLS_D)/bin


### PR DESCRIPTION
wget doesn't clobber downloads, it names the new version .1 , .2 etc.

This leaves the old stacker binary sitting there as 'stacker', like a banana waiting for someone to slip on.

If you first ran 'make test' a while ago, your subsequent tests will keep using that first version of stacker, even after a `make clean`, which does remove $(TOOLS_D)/bin/ , but does not remove `stacker` - you get a brand new stacker.1 and then you copy the old `stacker` back into your fresh TOOLS_D.

Fix this by moving stacker after downloading it instead of copying.