### PR TITLE
test: remove ubuntu 20.04 from CI matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     name: build
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
These runs are being cancelled because 20.04 support on github runners was turned off on 4/15