### PR TITLE
add backward compat code for root hash annotation name change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ GO_SRC := $(shell find . -name "*.go")
 VERSION_LDFLAGS=-X main.Version=$(MAIN_VERSION)
 BATS = $(TOOLS_D)/bin/bats
 BATS_VERSION := v1.10.0
+PRE_EROFS_STACKER = $(TOOLS_D)/bin/pre-erofs-stacker
+PRE_EROFS_STACKER_VERSION := v1.0.0
 STACKER = $(TOOLS_D)/bin/stacker
 STACKER_VERSION := v1.1.0-rc1
 TOOLS_D := $(ROOT)/tools
@@ -34,6 +36,11 @@ atomfs-cover: BUILDCOVERFLAGS=-cover
 gotest: $(GO_SRC)
 	go test -coverprofile=unit-coverage.txt -ldflags "$(VERSION_LDFLAGS)"  ./...
 
+$(PRE_EROFS_STACKER):
+	mkdir -p $(TOOLS_D)/bin
+	wget --progress=dot:giga https://github.com/project-stacker/stacker/releases/download/$(PRE_EROFS_STACKER_VERSION)/stacker --output-document $(TOOLS_D)/bin/pre-erofs-stacker
+	chmod +x $(TOOLS_D)/bin/pre-erofs-stacker
+
 $(STACKER):
 	mkdir -p $(TOOLS_D)/bin
 	wget --progress=dot:giga https://github.com/project-stacker/stacker/releases/download/$(STACKER_VERSION)/stacker
@@ -49,7 +56,7 @@ $(BATS):
 	git clone --depth 1 https://github.com/bats-core/bats-assert $(ROOT)/test/test_helper/bats-assert
 	git clone --depth 1 https://github.com/bats-core/bats-file $(ROOT)/test/test_helper/bats-file
 
-batstest: $(BATS) $(STACKER) atomfs-cover test/random.txt testimages
+batstest: $(BATS) $(STACKER) $(PRE_EROFS_STACKER) atomfs-cover test/random.txt testimages
 	cd $(ROOT)/test; sudo GOCOVERDIR=$(GOCOVERDIR) $(BATS) --tap --timing priv-*.bats
 	cd $(ROOT)/test; GOCOVERDIR=$(GOCOVERDIR) $(BATS) --tap --timing unpriv-*.bats
 	go tool covdata textfmt -i $(GOCOVERDIR) -o integ-coverage.txt

--- a/pkg/molecule/molecule.go
+++ b/pkg/molecule/molecule.go
@@ -73,10 +73,14 @@ func (m Molecule) mountUnderlyingAtoms() (error, func()) {
 
 		rootHash := a.Annotations[verity.VerityRootHashAnnotation]
 
+		if rootHash == "" {
+			rootHash = a.Annotations[verity.VerityRootHashAnnotation_Previous]
+		}
+
 		if !m.config.AllowMissingVerityData {
 
 			if rootHash == "" {
-				return errors.Errorf("%v is missing verity data", a.Digest), cleanupAtoms
+				return errors.Errorf("%v has no root hash in %q or %q, see: %+v", a.Digest, verity.VerityRootHashAnnotation, verity.VerityRootHashAnnotation_Previous, a.Annotations), cleanupAtoms
 			}
 			if !common.AmHostRoot() {
 				return errors.Errorf("won't guestmount an image with verity data without --allow-missing-verity"), cleanupAtoms

--- a/pkg/molecule/molecule_test.go
+++ b/pkg/molecule/molecule_test.go
@@ -22,5 +22,5 @@ func TestAllowMissingVerityData(t *testing.T) {
 
 	err, _ := mol.mountUnderlyingAtoms()
 	assert.NotNil(err)
-	assert.Equal(fmt.Sprintf("sha256:%s is missing verity data", hash), err.Error())
+	assert.Contains(err.Error(), fmt.Sprintf("sha256:%s has no root hash", hash))
 }

--- a/pkg/verity/verity.go
+++ b/pkg/verity/verity.go
@@ -90,6 +90,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const VerityRootHashAnnotation_Previous = "io.stackeroci.stacker.squashfs_verity_root_hash"
 const VerityRootHashAnnotation = "io.stackeroci.stacker.atomfs_verity_root_hash"
 
 type verityDeviceType struct {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -15,5 +15,6 @@ build_image_at() {
     stackerfilename=${2:-1.stacker.yaml}
     sudo env "PATH=$PATH" stacker --oci-dir $1/oci --stacker-dir=$1/stacker --roots-dir=$1/roots --debug build -f $(dirname $BATS_TEST_FILENAME)/$stackerfilename --layer-type squashfs
     sudo env "PATH=$PATH" stacker --oci-dir $1/oci-no-verity --stacker-dir=$1/stacker --roots-dir=$1/roots  --debug build -f $(dirname $BATS_TEST_FILENAME)/$stackerfilename --layer-type squashfs --no-squashfs-verity
-    sudo chown -R $(id -un):$(id -gn) $1/oci $1/oci-no-verity $1/stacker $1/roots
+    sudo env "PATH=$PATH" pre-erofs-stacker --oci-dir $1/oci-pre-erofs --stacker-dir=$1/stacker-pre-erofs --roots-dir=$1/roots-pre-erofs --debug build -f $(dirname $BATS_TEST_FILENAME)/$stackerfilename --layer-type squashfs
+    sudo chown -R $(id -un):$(id -gn) $1/oci $1/oci-no-verity $1/oci-pre-erofs $1/stacker $1/stacker-pre-erofs $1/roots $1/roots-pre-erofs
 }

--- a/test/priv-mount.bats
+++ b/test/priv-mount.bats
@@ -43,7 +43,7 @@ function setup() {
 @test "mount with missing verity data fails" {
     run atomfs-cover --debug mount ${BATS_SUITE_TMPDIR}/oci-no-verity:test-squashfs $MP
     assert_failure
-    assert_line --partial "is missing verity data"
+    assert_line --partial "has no root hash"
 
     # mount point and meta dir should exist but be empty:
     assert_dir_exists $MP
@@ -119,4 +119,23 @@ function setup() {
     # but persist dir should still be there:
     assert_file_exists $PERSIST_DIR/persist/this-time-let-me
     assert_file_exists $PERSIST_DIR/persist/3.README.md
+}
+
+
+@test "mount of image built with pre-erofs stacker works" {
+
+    cp -r ${BATS_SUITE_TMPDIR}/oci-pre-erofs /tmp/1-test-preerofs
+
+    run atomfs-cover --debug mount ${BATS_SUITE_TMPDIR}/oci-pre-erofs:test-squashfs $MP
+    assert_success
+
+    run atomfs-cover --debug umount $MP
+    assert_success
+
+    # mount point and meta dir should exist but be empty:
+    assert_dir_exists $MP
+    assert [ -z $( ls -A $MP) ]
+    assert_dir_exists $ATOMFS_TEST_RUN_DIR/meta/$MY_MNTNSNAME/
+    assert [ -z $( ls -A $ATOMFS_TEST_RUN_DIR/meta/$MY_MNTNSNAME/ ) ]
+
 }


### PR DESCRIPTION
fall back to looking for the previous annotation hash name in order to continue to mount images built with stacker versions from before the name change.

Adds a test that uses an old stacker to build such an image.