### PR TITLE
fix: Include tag matching for MAIN_VERSION used in --version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: gotest atomfs
 
-MAIN_VERSION ?= $(shell git describe --always --dirty || echo no-git)
+MAIN_VERSION ?= $(shell git describe --always --tags --dirty || echo no-git)
 ifeq ($(MAIN_VERSION),$(filter $(MAIN_VERSION), "", no-git))
 $(error "Bad value for MAIN_VERSION: '$(MAIN_VERSION)'")
 endif
@@ -85,3 +85,6 @@ toolsclean:
 clean:  toolsclean
 	rm -rf $(ROOT)/bin
 	rm -f .made-*
+
+debug:
+	@echo MAIN_VERSION=$(MAIN_VERSION)


### PR DESCRIPTION
The atomfs --version output should match the build version; currently it either shows just the git hash, or an incorrect older tag plus hash.  For example v1.2.0 was tagged back in early 2025, but if you build tip of the tree, the --version shows 1.1.2-XXXX

$ ./bin/atomfs --version
v1.1.2-9-gb584303

Add --tags to the git-describe output to match tags as well.

Fixes: #45 