### PR TITLE
fix: drop Ubuntu Focal (20.04) build from github workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     name: build
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The 20.04 runner on github is not reliable and being depricated[1] and notes final retire date is 2025-04-15.  We're past that now and seeing issues.

This PR drops the 20.04 from the github workflow matrix.

1. https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/