### PR TITLE
feat: Add arm64 build and test support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,10 +6,13 @@ name: build
 jobs:
   build:
     strategy:
+      fail-fast: true
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
-    name: build
-    runs-on: ${{ matrix.os }}
+        platform:
+          - linux-amd64  # ubuntu 24.04
+          - linux-arm64  # ubuntu 24.04-arm64
+    runs-on: ${{ matrix.platform == 'linux-amd64' && 'ubuntu-24.04' || matrix.platform == 'linux-arm64' && 'ubuntu-24.04-arm' }}
+    name: build-${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v5
       - name: Set up golang
@@ -63,7 +66,7 @@ jobs:
           go get -v ./...
           make atomfs
           cp ./bin/atomfs ~/bin
-          cp ./bin/atomfs atomfs-${{ matrix.os }}
+          cp ./bin/atomfs atomfs-${{ matrix.platform }}
       - name: test
         run: |
           make batstest
@@ -78,4 +81,4 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            atomfs-${{ matrix.os }}
+            atomfs-${{ matrix.platform }}

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,15 @@ endif
 ROOT := $(shell git rev-parse --show-toplevel)
 GO_SRC_DIRS := $(shell find . -name "*.go" | xargs -n1 dirname | sort -u)
 GO_SRC := $(shell find . -name "*.go")
+GOARCH := $(shell go env GOARCH)
+GOOS := $(shell go env GOOS)
 VERSION_LDFLAGS=-X main.Version=$(MAIN_VERSION)
 BATS = $(TOOLS_D)/bin/bats
 BATS_VERSION := v1.10.0
 PRE_EROFS_STACKER = $(TOOLS_D)/bin/pre-erofs-stacker
 PRE_EROFS_STACKER_VERSION := v1.0.0
 STACKER = $(TOOLS_D)/bin/stacker
-STACKER_VERSION := v1.1.0-rc1
+STACKER_VERSION := v1.1.3
 TOOLS_D := $(ROOT)/tools
 GOCOVERDIR ?= $(ROOT)
 
@@ -43,7 +45,7 @@ $(PRE_EROFS_STACKER):
 
 $(STACKER):
 	mkdir -p $(TOOLS_D)/bin
-	wget --progress=dot:giga https://github.com/project-stacker/stacker/releases/download/$(STACKER_VERSION)/stacker --output-document $(TOOLS_D)/bin/stacker
+	wget --progress=dot:giga https://github.com/project-stacker/stacker/releases/download/$(STACKER_VERSION)/stacker-$(GOOS)-$(GOARCH) --output-document $(TOOLS_D)/bin/stacker
 	chmod +x $(TOOLS_D)/bin/stacker
 
 $(BATS):

--- a/pkg/verity/verity.go
+++ b/pkg/verity/verity.go
@@ -111,7 +111,7 @@ func (verity verityDeviceType) Unmanaged() (unsafe.Pointer, func()) {
 	cParams.fec_device = nil
 	cParams.fec_roots = 0
 
-	cParams.salt_size = 32 // DEFAULT_VERITY_SALT_SIZE for x86
+	cParams.salt_size = 32 // DEFAULT_VERITY_SALT_SIZE
 	cParams.salt = nil
 
 	// these can't be larger than a page size, but we want them to be as

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -6,15 +6,23 @@ check_root(){
     fi
 }
 
-ROOT_D=$(dirname $BATS_TEST_FILENAME)/..
+ROOT_D=$(dirname "$BATS_TEST_FILENAME")/..
 TOOLS_D=$ROOT_D/tools
 export PATH="$TOOLS_D/bin:$ROOT_D/bin:$PATH"
 
 build_image_at() {
-    cd $1
+    cd "$1" || return 1
     stackerfilename=${2:-1.stacker.yaml}
-    sudo env "PATH=$PATH" stacker --oci-dir $1/oci --stacker-dir=$1/stacker --roots-dir=$1/roots --debug build -f $(dirname $BATS_TEST_FILENAME)/$stackerfilename --layer-type squashfs
-    sudo env "PATH=$PATH" stacker --oci-dir $1/oci-no-verity --stacker-dir=$1/stacker --roots-dir=$1/roots  --debug build -f $(dirname $BATS_TEST_FILENAME)/$stackerfilename --layer-type squashfs --no-squashfs-verity
-    sudo env "PATH=$PATH" pre-erofs-stacker --oci-dir $1/oci-pre-erofs --stacker-dir=$1/stacker-pre-erofs --roots-dir=$1/roots-pre-erofs --debug build -f $(dirname $BATS_TEST_FILENAME)/$stackerfilename --layer-type squashfs
-    sudo chown -R $(id -un):$(id -gn) $1/oci $1/oci-no-verity $1/oci-pre-erofs $1/stacker $1/stacker-pre-erofs $1/roots $1/roots-pre-erofs
+    sudo env "PATH=$PATH" stacker --oci-dir "$1/oci" --stacker-dir="$1/stacker" --roots-dir="$1/roots" --debug build -f "$(dirname "$BATS_TEST_FILENAME")/$stackerfilename" --layer-type squashfs
+    sudo env "PATH=$PATH" stacker --oci-dir "$1/oci-no-verity" --stacker-dir="$1/stacker" --roots-dir="$1/roots" --debug build -f "$(dirname "$BATS_TEST_FILENAME")/$stackerfilename" --layer-type squashfs --no-squashfs-verity
+    PRE_EROFS="$1/oci-pre-erofs $1/stacker-pre-erofs $1/roots-pre-erofs"
+    if [ "$(uname -m)" != "x86_64" ]; then
+        echo "skipping pre-erofs-stacker build. no support for arch $(uname -m)"
+        PRE_EROFS=""
+    else
+        sudo env "PATH=$PATH" pre-erofs-stacker --oci-dir "$1/oci-pre-erofs" --stacker-dir="$1/stacker-pre-erofs" --roots-dir="$1/roots-pre-erofs" --debug build -f "$(dirname "$BATS_TEST_FILENAME")/$stackerfilename" --layer-type squashfs
+    fi
+    # we want PRE_EROFS to expand and split
+    # shellcheck disable=SC2086
+    sudo chown -R "$(id -un):$(id -gn)" "$1/oci" "$1/oci-no-verity" "$1/stacker" "$1/roots" ${PRE_EROFS}
 }

--- a/test/priv-mount.bats
+++ b/test/priv-mount.bats
@@ -16,6 +16,10 @@ function setup() {
     mkdir -p $MP
 }
 
+function require_x86() {
+    [ "$(uname -m)" = "x86_64" ] || skip "test expected ARCH=x86_64 found ARCH=$(uname -m)"
+}
+
 @test "RO mount/umount and verify of good image works" {
     run atomfs-cover --debug mount ${BATS_SUITE_TMPDIR}/oci:test-squashfs $MP
     assert_success
@@ -123,6 +127,8 @@ function setup() {
 
 
 @test "mount of image built with pre-erofs stacker works" {
+
+    require_x86
 
     cp -r ${BATS_SUITE_TMPDIR}/oci-pre-erofs /tmp/1-test-preerofs
 


### PR DESCRIPTION
- Update github build workflow to build on 24.04 x86_64 and arm64
- Update artifacts to be named atomfs-$GOOS-$GOARCH:
  - atomfs-linux-amd64
  - atomfs-linux-arm64
- Update tests to skip building pre-erofs image if not on x86_64 arch since we don't have an arm64 build of the pre-erofs stacker
- Updated comment in verity.go to drop default size for x86; it's just the default size for verity struct