### PR TITLE
feat: simplify mounting as non-root

### DIFF
--- a/pkg/molecule/molecule.go
+++ b/pkg/molecule/molecule.go
@@ -74,6 +74,11 @@ func (m Molecule) mountUnderlyingAtoms() (error, func()) {
 	}
 	noop := func() {}
 
+	if !m.config.AllowMissingVerityData && !common.AmHostRoot() {
+		log.Warnf("Not host root: will guestmount the image without using fsverity data")
+		m.config.AllowMissingVerityData = true
+	}
+
 	for _, a := range m.Atoms {
 		target, err := m.MountedAtomsPath(a.Digest.Encoded())
 		if err != nil {
@@ -87,12 +92,8 @@ func (m Molecule) mountUnderlyingAtoms() (error, func()) {
 		}
 
 		if !m.config.AllowMissingVerityData {
-
 			if rootHash == "" {
 				return errors.Errorf("%v has no root hash in %q or %q, see: %+v", a.Digest, verity.VerityRootHashAnnotation, verity.VerityRootHashAnnotation_Previous, a.Annotations), cleanupAtoms
-			}
-			if !common.AmHostRoot() {
-				return errors.Errorf("won't guestmount an image with verity data without --allow-missing-verity"), cleanupAtoms
 			}
 		}
 

--- a/pkg/molecule/molecule_test.go
+++ b/pkg/molecule/molecule_test.go
@@ -7,12 +7,16 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
+	"machinerun.io/atomfs/pkg/common"
 )
 
 func TestAllowMissingVerityData(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
+	if !common.AmHostRoot() {
+		t.Skip("Not host root, skipping missing verify test")
+	}
 	// no root hash annotations on this descriptor...
 	const hash = "73cd1a9ab86defeb5e22151ceb96b347fc58b4318f64be05046c51d407a364eb"
 	d := digest.NewDigestFromEncoded(digest.Algorithm("sha256"), hash)


### PR DESCRIPTION
If you are not root on the host, you can't mount with fs-verity. Atomfs currently makes you add the --allow-missing-verity flag to mount without verify.  This means that non-host-root has to always specify that flag.  That's silly, not helpful, and makes use in unprivileged lxc more painful.

Still spit out a warning, but don't refuse to mount if you are not host root.